### PR TITLE
Adding ability to send IP address from API routes

### DIFF
--- a/src/Contracts/ViewableService.php
+++ b/src/Contracts/ViewableService.php
@@ -49,7 +49,7 @@ interface ViewableService
      * @param  \Illuminate\Database\Eloquent\Model  $viewable
      * @return bool
      */
-    public function addViewTo($viewable): bool;
+    public function addViewTo($viewable, $ip = ''): bool;
 
     /**
      * Remove all views from a viewable model.

--- a/src/Support/IpAddress.php
+++ b/src/Support/IpAddress.php
@@ -28,8 +28,12 @@ class IpAddress
      *
      * @return bool
      */
-    public function get()
+    public function get($ip = '')
     {
-        return Request::ip();
+        if(empty($ip)){
+          return Request::ip();
+        } else {
+          return $ip;
+        }
     }
 }

--- a/src/Viewable.php
+++ b/src/Viewable.php
@@ -73,9 +73,9 @@ trait Viewable
      *
      * @return bool
      */
-    public function addView(): bool
+    public function addView($ip = ''): bool
     {
-        return app(ViewableService::class)->addViewTo($this);
+        return app(ViewableService::class)->addViewTo($this, $ip);
     }
 
     /**

--- a/src/ViewableService.php
+++ b/src/ViewableService.php
@@ -171,7 +171,7 @@ class ViewableService implements ViewableServiceContract
      * @param  \Illuminate\Database\Eloquent\Model  $viewable
      * @return bool
      */
-    public function addViewTo($viewable): bool
+    public function addViewTo($viewable, $ip = ''): bool
     {
         $ignoreBots = config('eloquent-viewable.ignore_bots', true);
         $honorToDnt = config('eloquent-viewable.honor_dnt', false);
@@ -190,12 +190,12 @@ class ViewableService implements ViewableServiceContract
 
         $ignoredIpAddresses = Collection::make(config('eloquent-viewable.ignored_ip_addresses', []));
 
-        if ($ignoredIpAddresses->contains($this->ipRepository->get())) {
+        if ($ignoredIpAddresses->contains($this->ipRepository->get($ip))) {
             return false;
         }
 
         $visitorCookie = Cookie::get($cookieName);
-        $visitor = $visitorCookie ?? $this->ipRepository->get();
+        $visitor = $visitorCookie ?? $this->ipRepository->get($ip);
 
         $view = app(ViewContract::class);
         $view->viewable_id = $viewable->getKey();


### PR DESCRIPTION
Fixes #82

If you are using this library as a backend server for native applications like Android or IOS you can send the IP address from the application through HTTP request like below:
`$post->addView($ip);`