### PR TITLE
[v3] Add view collections feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In this documentation, you will find some helpful information about the use of t
     * [Retrieving views counts](#retrieving-views-counts)
     * [Order models by views count](#order-models-by-views-count)
 3. [Advanced Usage](#advanced-usage)
-    * [Tagging views](#tagging-views)
+    * [View collections](#view-collections)
     * [Supplying your own visitor's IP Address](#supplying-your-own-visitors-ip-address)
     * [Queuing views](#queuing-views)
     * [Caching view counts](#caching-view-counts)
@@ -332,21 +332,21 @@ views()->countByType($post);
 
 ## Advanced Usage
 
-### Tagging views
+### View collections
 
-Sometimes, you may need to have multiple view counters for one viewable type. To record views under a tag, you can easily call the `tag()` method on the chain.
+If you have different types of views for the same viewable type, you may want to store them in their own collection.
 
 ```php
 views($post)
-    ->tag('customTag')
+    ->collection('customCollection')
     ->record();
 ```
 
-To retrieve the views count with this tag, you can reuse the same `tag()` method.
+To retrieve the views count in a specific collection, you can reuse the same `collection()` method.
 
 ```php
 views($post)
-    ->tag('customTag')
+    ->collection('customCollection')
     ->count();
 ```
 

--- a/migrations/2018_11_10_125700_create_views_table.php
+++ b/migrations/2018_11_10_125700_create_views_table.php
@@ -45,7 +45,7 @@ class CreateViewsTable extends Migration
             $table->increments('id');
             $table->morphs('viewable');
             $table->text('visitor')->nullable();
-            $table->text('tag')->nullable();
+            $table->string('collection')->nullable();
             $table->timestamp('viewed_at')->useCurrent();
         });
     }

--- a/src/Support/Key.php
+++ b/src/Support/Key.php
@@ -25,7 +25,7 @@ class Key
      * @param  bool  $unique
      * @return string
      */
-    public static function createForEntity(ViewableContract $viewable, $period, bool $unique, string $tag = null): string
+    public static function createForEntity(ViewableContract $viewable, $period, bool $unique, string $collection = null): string
     {
         $cacheKey = config('eloquent-viewable.cache.key', 'cyrildewit.eloquent-viewable.cache');
 
@@ -35,9 +35,9 @@ class Key
         $typeKey = $unique ? 'unique' : 'normal';
         $periodKey = static::createPeriodKey($period);
 
-        $tag = $tag ? ".{$tag}" : '';
+        $collection = $collection ? ".{$collection}" : '';
 
-        return "{$cacheKey}{$tag}.{$viewableType}.{$viewableKey}.{$typeKey}.{$periodKey}";
+        return "{$cacheKey}{$collection}.{$viewableType}.{$viewableKey}.{$typeKey}.{$periodKey}";
     }
 
     /**

--- a/src/Views.php
+++ b/src/Views.php
@@ -58,11 +58,11 @@ class Views
     protected $sessionDelay = null;
 
     /**
-     * The tag under which view will be saved.
+     * The collection under where the view will be saved.
      *
      * @var string|null
      */
-    protected $tag = null;
+    protected $collection = null;
 
     /**
      * Determine if the views count should be cached.
@@ -202,7 +202,7 @@ class Views
             $view->viewable_id = $this->viewable->getKey();
             $view->viewable_type = $this->viewable->getMorphClass();
             $view->visitor = $this->resolveVisitorId();
-            $view->tag = $this->tag;
+            $view->collection = $this->collection;
             $view->viewed_at = Carbon::now();
 
             return $view->save();
@@ -220,7 +220,7 @@ class Views
     {
         $query = $this->viewable->views();
 
-        $cacheKey = Key::createForEntity($this->viewable, $this->period ?? Period::create(), $this->unique, $this->tag);
+        $cacheKey = Key::createForEntity($this->viewable, $this->period ?? Period::create(), $this->unique, $this->collection);
 
         if ($this->shouldCache) {
             $cachedViewsCount = $this->cache->get($cacheKey);
@@ -234,9 +234,7 @@ class Views
             $query->withinPeriod($period);
         }
 
-        if ($tag = $this->tag) {
-            $query->where('tag', $tag);
-        }
+        $query->where('collection', $this->collection);
 
         if ($this->unique) {
             $viewsCount = $query->uniqueVisitor()->count('visitor');
@@ -301,14 +299,14 @@ class Views
     }
 
     /**
-     * Set a tag.
+     * Set the collection.
      *
      * @param  string
      * @return self
      */
-    public function tag($tag): self
+    public function collection(string $name): self
     {
-        $this->tag = $tag;
+        $this->collection = $name;
 
         return $this;
     }

--- a/tests/Unit/Models/ViewTest.php
+++ b/tests/Unit/Models/ViewTest.php
@@ -53,7 +53,14 @@ class ViewTest extends TestCase
         $this->assertNull($view->getAttribute('visitor'));
     }
 
-    // public function it_can_fill_tag();
+    public function it_can_fill_collection()
+    {
+        $view = new View([
+            'collection' => null,
+        ]);
+
+        $this->assertNull($view->getAttribute('collection'));
+    }
 
     /** @test */
     public function it_can_fill_viewed_at()

--- a/tests/Unit/ViewsTest.php
+++ b/tests/Unit/ViewsTest.php
@@ -81,15 +81,15 @@ class ViewsTest extends TestCase
     }
 
     /** @test */
-    public function it_can_record_a_view_under_a_tag()
+    public function it_can_record_a_view_under_a_collection()
     {
         views($this->post)
-            ->tag('customTag')
+            ->collection('customCollection')
             ->record();
 
         views($this->post)->record();
 
-        $this->assertEquals(1, views($this->post)->tag('customTag')->count());
+        $this->assertEquals(1, View::where('collection', 'customCollection')->count());
     }
 
     /** @test */
@@ -145,6 +145,17 @@ class ViewsTest extends TestCase
         $this->assertEquals(6, views($this->post)->period(Period::since(Carbon::parse('2018-01-10')))->count());
         $this->assertEquals(4, views($this->post)->period(Period::upto(Carbon::parse('2018-02-15')))->count());
         $this->assertEquals(4, views($this->post)->period(Period::create(Carbon::parse('2018-01-15'), Carbon::parse('2018-03-10')))->count());
+    }
+
+    /** @test */
+    public function it_can_count_the_views_with_a_collection()
+    {
+        views($this->post)->collection('custom')->record();
+        views($this->post)->collection('custom')->record();
+        views($this->post)->record();
+
+        $this->assertEquals(2, views($this->post)->collection('custom')->count());
+        $this->assertEquals(1, views($this->post)->count());
     }
 
     /** @test */


### PR DESCRIPTION
**From the documentation:**

If you have different types of views for the same viewable type, you may want to store them in their own collection.

```php
views($post)
    ->collection('customCollection')
    ->record();
```

To retrieve the views count in a specific collection, you can reuse the same `collection()` method.

```php
views($post)
    ->collection('customCollection')
    ->count();
```