### PR TITLE
fix: type cast the cached views count otherwise type hint will fail

### DIFF
--- a/src/Views.php
+++ b/src/Views.php
@@ -166,7 +166,7 @@ class Views
             $cachedViewsCount = $this->cache->get($cacheKey);
 
             if ($cachedViewsCount !== null) {
-                return $cachedViewsCount;
+                return (int) $cachedViewsCount;
             }
         }
 
@@ -225,7 +225,7 @@ class Views
             $cachedViewsCount = $this->cache->get($cacheKey);
 
             if ($cachedViewsCount !== null) {
-                return $cachedViewsCount;
+                return (int) $cachedViewsCount;
             }
         }
 


### PR DESCRIPTION
Fixes #67 in `v3`.

@ScottyRobinson thank you for noticing!