### PR TITLE
Don't run tests with --debug in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
-  - vendor/bin/phpunit --debug
+  - vendor/bin/phpunit
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
It really isn't necessary to run `phpunit` with the `--debug` flag in CI. It only makes the tests run slower, and cause extra (possibly confusing) output.