### PR TITLE
fix(remember): update property assignment (typo)

### DIFF
--- a/src/Views.php
+++ b/src/Views.php
@@ -343,7 +343,7 @@ class Views
     public function remember($lifetime = null)
     {
         $this->shouldCache = true;
-        $this->cacheLifetiem = $lifetime;
+        $this->cacheLifetime = $lifetime;
 
         return $this;
     }


### PR DESCRIPTION
Fix typo in `Views::remember()`

---

`$this->cacheLifetiem` --> `$this->cacheLifetime`