### PR TITLE
Release/v3.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 build/
-build/
 doc/
 vendor/
 node_modules/
 .vscode/
 composer.lock
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add support for Laravel 5.8
 
+### Changed
+
+- Use String and Array classes instead of the helper functions
+
 ## [v3.1.0] (2019-01-29)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `Eloquent Viewable` will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## [v3.2.0] (2019-03-03)
+
+### Added
+
+- Add support for Laravel 5.8
+
 ## [v3.1.0] (2019-01-29)
 
 ### Fixed
@@ -148,7 +156,9 @@ This major version contains some serious breaking changes! See the [upgrade guid
 - Removed the `addPageViewThatExpiresAt` method from the `Viewable` trait
 - The DateTransformer functionality has been removed
 
-[Unreleased]: https://github.com/cyrildewit/eloquent-viewable/compare/v3.0.2...HEAD
+[Unreleased]: https://github.com/cyrildewit/eloquent-viewable/compare/v3.2.0...HEAD
+[v3.2.0]: https://github.com/cyrildewit/eloquent-viewable/compare/v3.1.0...v3.2.0
+[v3.1.0]: https://github.com/cyrildewit/eloquent-viewable/compare/v3.0.2...v3.1.0
 [v3.0.2]: https://github.com/cyrildewit/eloquent-viewable/compare/v3.0.1...v3.0.2
 [v3.0.1]: https://github.com/cyrildewit/eloquent-viewable/compare/v3.0.0...v3.0.1
 [v3.0.0]: https://github.com/cyrildewit/eloquent-viewable/compare/v2.3.3...v3.0.0

--- a/README.md
+++ b/README.md
@@ -502,6 +502,14 @@ Views::macro('countAndCache', function () {
 });
 ```
 
+Now you're able to use this shorthand like this:
+
+```php
+views($post)->countAndCache();
+
+Views::forViewable($post)->countAndCache();
+```
+
 ## Upgrading
 
 Please see [UPGRADING](UPGRADING.md) for detailed upgrade guide.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
+         cacheResult="true"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"

--- a/src/Support/Period.php
+++ b/src/Support/Period.php
@@ -16,6 +16,7 @@ namespace CyrildeWit\EloquentViewable\Support;
 use DateTime;
 use Exception;
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 use CyrildeWit\EloquentViewable\Exceptions\InvalidPeriod;
 
 /**
@@ -277,7 +278,7 @@ class Period
      */
     public static function subToday(string $subType, int $subValue): self
     {
-        $subTypeMethod = 'sub'.ucfirst(strtolower(str_after($subType, 'PAST_')));
+        $subTypeMethod = 'sub'.ucfirst(strtolower(Str::after($subType, 'PAST_')));
         $today = Carbon::today();
 
         return self::sub($today, $subTypeMethod, $subType, $subValue);
@@ -294,7 +295,7 @@ class Period
      */
     public static function subNow(string $subType, int $subValue): self
     {
-        $subTypeMethod = 'sub'.ucfirst(strtolower(str_after($subType, 'SUB_')));
+        $subTypeMethod = 'sub'.ucfirst(strtolower(Str::after($subType, 'SUB_')));
         $now = Carbon::now();
 
         return self::sub($now, $subTypeMethod, $subType, $subValue);

--- a/src/Views.php
+++ b/src/Views.php
@@ -272,7 +272,7 @@ class Views
      * Set the viewable model.
      *
      * @param  \CyrildeWit\EloquentViewable\Contracts\Viewable|null
-     * @return self
+     * @return $this
      */
     public function forViewable(ViewableContract $viewable = null): self
     {
@@ -285,7 +285,7 @@ class Views
      * Set the delay in the session.
      *
      * @param  \DateTime|int  $delay
-     * @return self
+     * @return $this
      */
     public function delayInSession($delay): self
     {
@@ -302,7 +302,7 @@ class Views
      * Set the period.
      *
      * @param  \CyrildeWit\EloquentViewable\Period
-     * @return self
+     * @return $this
      */
     public function period($period): self
     {
@@ -315,7 +315,7 @@ class Views
      * Set the collection.
      *
      * @param  string
-     * @return self
+     * @return $this
      */
     public function collection(string $name): self
     {
@@ -328,7 +328,7 @@ class Views
      * Fetch only unique views.
      *
      * @param  bool  $state
-     * @return self
+     * @return $this
      */
     public function unique(bool $state = true): self
     {
@@ -340,8 +340,8 @@ class Views
     /**
      * Cache the current views count.
      *
-     * @param  \DateTime|int  $lifetime
-     * @return self
+     * @param  \DateTime|int|null  $lifetime
+     * @return $this
      */
     public function remember($lifetime = null)
     {
@@ -360,7 +360,7 @@ class Views
      * Override the visitor's IP Address.
      *
      * @param  string  $address
-     * @return self
+     * @return $this
      */
     public function overrideIpAddress(string $address)
     {
@@ -373,7 +373,7 @@ class Views
      * Override the visitor's unique ID.
      *
      * @param  string  $visitor
-     * @return self
+     * @return $this
      */
     public function overrideVisitor(string $visitor)
     {

--- a/src/Views.php
+++ b/src/Views.php
@@ -72,7 +72,7 @@ class Views
     protected $shouldCache = false;
 
     /**
-     * Determine if the views count should be cached.
+     * Cache lifetime.
      *
      * @var \DateTime
      */

--- a/src/VisitorCookieRepository.php
+++ b/src/VisitorCookieRepository.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CyrildeWit\EloquentViewable;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Cookie;
 
 class VisitorCookieRepository
@@ -57,7 +58,7 @@ class VisitorCookieRepository
      */
     protected function generateUniqueString(): string
     {
-        return str_random(80);
+        return Str::random(80);
     }
 
     /**


### PR DESCRIPTION
This pull request contains the final changes that we need to make before we can release  `v3.2.0`.

This release provides support for Laravel 5.8. I replaced all internal calls to the deprecated `str_*` and `array_*` methods with their actual classes. I secondly improved some docblocks and updated the changelog.

---

One note for further PR's, is that I'm going to remove the `3.x` branch since this is basically the same as `master`. I will revert this change once version 4 of this package comes out.