### PR TITLE
Fix bugs in orderBy scopes

### DIFF
--- a/src/Support/Key.php
+++ b/src/Support/Key.php
@@ -72,7 +72,7 @@ class Key
             return "{$period->getStartDateTimeString()}|{$period->getEndDateTimeString()}";
         }
 
-        list($subType, $subValueType) = explode('_', strtolower($period->getSubType()));
+        [$subType, $subValueType] = explode('_', strtolower($period->getSubType()));
 
         return "{$subType}{$period->getSubValue()}{$subValueType}|";
     }

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -24,7 +24,7 @@ class TestHelper
      * @param  array  $data
      * @return \CyrildeWit\EloquentViewable\View
      */
-    public static function createNewView($model, $data = [])
+    public static function createView($model, $data = [])
     {
         return View::create([
             'viewable_id' => $model->getKey(),

--- a/tests/Unit/ViewableObserverTest.php
+++ b/tests/Unit/ViewableObserverTest.php
@@ -33,9 +33,9 @@ class ViewableObserverTest extends TestCase
     /** @test */
     public function it_can_destroy_all_views_when_viewable_gets_deleted()
     {
-        TestHelper::createNewView($this->post);
-        TestHelper::createNewView($this->post);
-        TestHelper::createNewView($this->post);
+        TestHelper::createView($this->post);
+        TestHelper::createView($this->post);
+        TestHelper::createView($this->post);
 
         $this->assertEquals(3, View::count());
 
@@ -49,9 +49,9 @@ class ViewableObserverTest extends TestCase
     {
         $this->post->removeViewsOnDelete = false;
 
-        TestHelper::createNewView($this->post);
-        TestHelper::createNewView($this->post);
-        TestHelper::createNewView($this->post);
+        TestHelper::createView($this->post);
+        TestHelper::createView($this->post);
+        TestHelper::createView($this->post);
 
         $this->assertEquals(3, View::count());
 

--- a/tests/Unit/ViewableTest.php
+++ b/tests/Unit/ViewableTest.php
@@ -40,7 +40,7 @@ class ViewableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_be_ordered_by_views_count_in_descending_order()
+    public function it_can_be_ordered_by_views_in_descending_order()
     {
         $postOne = $this->post;
         $postTwo = factory(Post::class)->create();
@@ -59,26 +59,7 @@ class ViewableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_be_ordered_by_views_count_in_ascending_order()
-    {
-        $postOne = $this->post;
-        $postTwo = factory(Post::class)->create();
-        $postThree = factory(Post::class)->create();
-
-        TestHelper::createNewView($postOne);
-        TestHelper::createNewView($postOne);
-        TestHelper::createNewView($postOne);
-
-        TestHelper::createNewView($postTwo);
-
-        TestHelper::createNewView($postThree);
-        TestHelper::createNewView($postThree);
-
-        $this->assertEquals(collect([2, 3, 1]), Post::orderByViews('asc')->pluck('id'));
-    }
-
-    /** @test */
-    public function it_can_be_ordered_by_unique_views_count_in_descending_order()
+    public function it_can_be_ordered_by_unique_views_in_descending_order()
     {
         $postOne = $this->post;
         $postTwo = factory(Post::class)->create();
@@ -97,7 +78,26 @@ class ViewableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_be_ordered_by_unique_views_count_in_ascending_order()
+    public function it_can_be_ordered_by_views_in_ascending_order()
+    {
+        $postOne = $this->post;
+        $postTwo = factory(Post::class)->create();
+        $postThree = factory(Post::class)->create();
+
+        TestHelper::createNewView($postOne);
+        TestHelper::createNewView($postOne);
+        TestHelper::createNewView($postOne);
+
+        TestHelper::createNewView($postTwo);
+
+        TestHelper::createNewView($postThree);
+        TestHelper::createNewView($postThree);
+
+        $this->assertEquals(collect([2, 3, 1]), Post::orderByViews('asc')->pluck('id'));
+    }
+
+    /** @test */
+    public function it_can_be_ordered_by_unique_views_in_ascending_order()
     {
         $postOne = $this->post;
         $postTwo = factory(Post::class)->create();
@@ -116,7 +116,7 @@ class ViewableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_be_ordered_by_views_count_with_a_specific_period_in_descending_order()
+    public function it_can_be_ordered_by_views_within_a_specific_period_in_descending_order()
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -140,31 +140,7 @@ class ViewableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_be_ordered_by_views_count_with_a_specific_period_in_ascending_order()
-    {
-        Carbon::setTestNow(Carbon::now());
-
-        $postOne = $this->post;
-        $postTwo = factory(Post::class)->create();
-        $postThree = factory(Post::class)->create();
-
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
-
-        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
-
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
-
-        $this->assertEquals(collect([2, 3, 1]), Post::orderByViews('asc', Period::pastDays(10))->pluck('id'));
-    }
-
-    /** @test */
-    public function it_can_be_ordered_by_unique_views_count_with_a_specific_period_in_ascending_order()
+    public function it_can_be_ordered_by_unique_views_withing_a_specific_period_in_ascending_order()
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -186,5 +162,53 @@ class ViewableTest extends TestCase
         TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(18), 'visitor' => 'visitor_one']);
 
         $this->assertEquals(collect([3, 2, 1]), Post::orderByUniqueViews('asc', Period::pastDays(10))->pluck('id'));
+    }
+
+    /** @test */
+    public function it_can_be_ordered_by_views_withing_a_specific_period_in_descending_order()
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        $postOne = $this->post;
+        $postTwo = factory(Post::class)->create();
+        $postThree = factory(Post::class)->create();
+
+        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()]);
+        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
+        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
+        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
+
+        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()]);
+        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
+
+        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()]);
+        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
+        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
+
+        $this->assertEquals(collect([1, 3, 2]), Post::orderByViews('desc', Period::pastDays(10))->pluck('id'));
+    }
+
+    /** @test */
+    public function it_can_be_ordered_by_views_withing_a_specific_period_in_ascending_order()
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        $postOne = $this->post;
+        $postTwo = factory(Post::class)->create();
+        $postThree = factory(Post::class)->create();
+
+        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()]);
+        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
+        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
+        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
+
+        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()]);
+        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
+
+        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()]);
+        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
+        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
+
+        $this->assertEquals(collect([2, 3, 1]), Post::orderByViews('asc', Period::pastDays(10))->pluck('id'));
     }
 }

--- a/tests/Unit/ViewableTest.php
+++ b/tests/Unit/ViewableTest.php
@@ -45,7 +45,9 @@ class ViewableTest extends TestCase
         $postOne = $this->post;
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
+        $postFour = factory(Post::class)->create();
 
+        TestHelper::createView($postOne);
         TestHelper::createView($postOne);
         TestHelper::createView($postOne);
         TestHelper::createView($postOne);
@@ -55,7 +57,11 @@ class ViewableTest extends TestCase
         TestHelper::createView($postThree);
         TestHelper::createView($postThree);
 
-        $this->assertEquals(collect([1, 3, 2]), Post::orderByViews()->pluck('id'));
+        TestHelper::createView($postFour);
+        TestHelper::createView($postFour);
+        TestHelper::createView($postFour);
+
+        $this->assertEquals(collect([1, 4, 3, 2]), Post::orderByViews()->pluck('id'));
     }
 
     /** @test */
@@ -64,55 +70,32 @@ class ViewableTest extends TestCase
         $postOne = $this->post;
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
+        $postFour = factory(Post::class)->create();
 
+        // Unque views: 3
+        TestHelper::createView($postOne, ['visitor' => 'visitor_one']);
         TestHelper::createView($postOne, ['visitor' => 'visitor_one']);
         TestHelper::createView($postOne, ['visitor' => 'visitor_two']);
         TestHelper::createView($postOne, ['visitor' => 'visitor_three']);
 
+        // Unque views: 2
         TestHelper::createView($postTwo, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postTwo, ['visitor' => 'visitor_two']);
+        TestHelper::createView($postTwo, ['visitor' => 'visitor_two']);
 
+        // Unque views: 4
+        TestHelper::createView($postThree, ['visitor' => 'visitor_one']);
         TestHelper::createView($postThree, ['visitor' => 'visitor_one']);
         TestHelper::createView($postThree, ['visitor' => 'visitor_two']);
+        TestHelper::createView($postThree, ['visitor' => 'visitor_three']);
+        TestHelper::createView($postThree, ['visitor' => 'visitor_four']);
 
-        $this->assertEquals(collect([1, 3, 2]), Post::orderByUniqueViews()->pluck('id'));
-    }
+        // Unque views: 1
+        TestHelper::createView($postFour, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postFour, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postFour, ['visitor' => 'visitor_two']);
 
-    /** @test */
-    public function it_can_be_ordered_by_views_in_ascending_order()
-    {
-        $postOne = $this->post;
-        $postTwo = factory(Post::class)->create();
-        $postThree = factory(Post::class)->create();
-
-        TestHelper::createView($postOne);
-        TestHelper::createView($postOne);
-        TestHelper::createView($postOne);
-
-        TestHelper::createView($postTwo);
-
-        TestHelper::createView($postThree);
-        TestHelper::createView($postThree);
-
-        $this->assertEquals(collect([2, 3, 1]), Post::orderByViews('asc')->pluck('id'));
-    }
-
-    /** @test */
-    public function it_can_be_ordered_by_unique_views_in_ascending_order()
-    {
-        $postOne = $this->post;
-        $postTwo = factory(Post::class)->create();
-        $postThree = factory(Post::class)->create();
-
-        TestHelper::createView($postOne, ['visitor' => 'visitor_one']);
-        TestHelper::createView($postOne, ['visitor' => 'visitor_two']);
-        TestHelper::createView($postOne, ['visitor' => 'visitor_three']);
-
-        TestHelper::createView($postTwo, ['visitor' => 'visitor_one']);
-
-        TestHelper::createView($postThree, ['visitor' => 'visitor_one']);
-        TestHelper::createView($postThree, ['visitor' => 'visitor_two']);
-
-        $this->assertEquals(collect([2, 3, 1]), Post::orderByUniqueViews('asc')->pluck('id'));
+        $this->assertEquals(collect([3, 1, 2, 4]), Post::orderByUniqueViews()->pluck('id'));
     }
 
     /** @test */
@@ -123,92 +106,122 @@ class ViewableTest extends TestCase
         $postOne = $this->post;
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
+        $postFour = factory(Post::class)->create();
 
+        // Views within period: 3
         TestHelper::createView($postOne, ['viewed_at' => Carbon::now()]);
         TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
         TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
         TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
 
+        // Views within period: 1
         TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()]);
         TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
 
+        // Views within period: 2
         TestHelper::createView($postThree, ['viewed_at' => Carbon::now()]);
         TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
         TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
 
-        $this->assertEquals(collect([1, 3, 2]), Post::orderByViews('desc', Period::pastDays(10))->pluck('id'));
+        // Views within period: 4
+        TestHelper::createView($postFour, ['viewed_at' => Carbon::now()]);
+        TestHelper::createView($postFour, ['viewed_at' => Carbon::now()->subDays(3)]);
+        TestHelper::createView($postFour, ['viewed_at' => Carbon::now()->subDays(4)]);
+        TestHelper::createView($postFour, ['viewed_at' => Carbon::now()->subDays(7)]);
+
+        $this->assertEquals(collect([4, 1, 3, 2]), Post::orderByViews('desc', Period::pastDays(10))->pluck('id'));
     }
 
     /** @test */
-    public function it_can_be_ordered_by_unique_views_withing_a_specific_period_in_ascending_order()
+    public function it_can_be_ordered_by_views_in_ascending_order()
+    {
+        $postOne = $this->post;
+        $postTwo = factory(Post::class)->create();
+        $postThree = factory(Post::class)->create();
+        $postFour = factory(Post::class)->create();
+
+        TestHelper::createView($postOne);
+        TestHelper::createView($postOne);
+        TestHelper::createView($postOne);
+        TestHelper::createView($postOne);
+
+        TestHelper::createView($postTwo);
+
+        TestHelper::createView($postThree);
+        TestHelper::createView($postThree);
+
+        TestHelper::createView($postFour);
+        TestHelper::createView($postFour);
+        TestHelper::createView($postFour);
+
+        $this->assertEquals(collect([2, 3, 4, 1]), Post::orderByViews('asc')->pluck('id'));
+    }
+
+    /** @test */
+    public function it_can_be_ordered_by_unique_views_in_ascending_order()
+    {
+        $postOne = $this->post;
+        $postTwo = factory(Post::class)->create();
+        $postThree = factory(Post::class)->create();
+        $postFour = factory(Post::class)->create();
+
+        // Unque views: 3
+        TestHelper::createView($postOne, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postOne, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postOne, ['visitor' => 'visitor_two']);
+        TestHelper::createView($postOne, ['visitor' => 'visitor_three']);
+
+        // Unque views: 2
+        TestHelper::createView($postTwo, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postTwo, ['visitor' => 'visitor_two']);
+        TestHelper::createView($postTwo, ['visitor' => 'visitor_two']);
+
+        // Unque views: 4
+        TestHelper::createView($postThree, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postThree, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postThree, ['visitor' => 'visitor_two']);
+        TestHelper::createView($postThree, ['visitor' => 'visitor_three']);
+        TestHelper::createView($postThree, ['visitor' => 'visitor_four']);
+
+        // Unque views: 1
+        TestHelper::createView($postFour, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postFour, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postFour, ['visitor' => 'visitor_two']);
+
+        $this->assertEquals(collect([4, 2, 1, 3]), Post::orderByUniqueViews('asc')->pluck('id'));
+    }
+
+    /** @test */
+    public function it_can_be_ordered_by_unique_views_within_a_specific_period_in_ascending_order()
     {
         Carbon::setTestNow(Carbon::now());
 
         $postOne = $this->post;
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
+        $postFour = factory(Post::class)->create();
 
-        TestHelper::createView($postOne, ['viewed_at' => Carbon::now(), 'visitor' => 'visitor_one']);
-        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(2), 'visitor' => 'visitor_one']);
-        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(8), 'visitor' => 'visitor_two']);
-        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(13), 'visitor' => 'visitor_three']);
-
-        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now(), 'visitor' => 'visitor_one']);
-        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()->subDays(5), 'visitor' => 'visitor_two']);
-        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()->subDays(13), 'visitor' => 'visitor_two']);
-
-        TestHelper::createView($postThree, ['viewed_at' => Carbon::now(), 'visitor' => 'visitor_one']);
-        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(14), 'visitor' => 'visitor_one']);
-        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(18), 'visitor' => 'visitor_one']);
-
-        $this->assertEquals(collect([3, 2, 1]), Post::orderByUniqueViews('asc', Period::pastDays(10))->pluck('id'));
-    }
-
-    /** @test */
-    public function it_can_be_ordered_by_views_withing_a_specific_period_in_descending_order()
-    {
-        Carbon::setTestNow(Carbon::now());
-
-        $postOne = $this->post;
-        $postTwo = factory(Post::class)->create();
-        $postThree = factory(Post::class)->create();
-
+        // Views within period: 3
         TestHelper::createView($postOne, ['viewed_at' => Carbon::now()]);
         TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
         TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
         TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
 
+        // Views within period: 1
         TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()]);
         TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
 
+        // Views within period: 2
         TestHelper::createView($postThree, ['viewed_at' => Carbon::now()]);
         TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
         TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
 
-        $this->assertEquals(collect([1, 3, 2]), Post::orderByViews('desc', Period::pastDays(10))->pluck('id'));
-    }
+        // Views within period: 4
+        TestHelper::createView($postFour, ['viewed_at' => Carbon::now()]);
+        TestHelper::createView($postFour, ['viewed_at' => Carbon::now()->subDays(3)]);
+        TestHelper::createView($postFour, ['viewed_at' => Carbon::now()->subDays(4)]);
+        TestHelper::createView($postFour, ['viewed_at' => Carbon::now()->subDays(7)]);
 
-    /** @test */
-    public function it_can_be_ordered_by_views_withing_a_specific_period_in_ascending_order()
-    {
-        Carbon::setTestNow(Carbon::now());
-
-        $postOne = $this->post;
-        $postTwo = factory(Post::class)->create();
-        $postThree = factory(Post::class)->create();
-
-        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()]);
-        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
-        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
-        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
-
-        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()]);
-        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
-
-        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()]);
-        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
-        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
-
-        $this->assertEquals(collect([2, 3, 1]), Post::orderByViews('asc', Period::pastDays(10))->pluck('id'));
+        $this->assertEquals(collect([2, 3, 1, 4]), Post::orderByUniqueViews('asc', Period::pastDays(10))->pluck('id'));
     }
 }

--- a/tests/Unit/ViewableTest.php
+++ b/tests/Unit/ViewableTest.php
@@ -46,14 +46,14 @@ class ViewableTest extends TestCase
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
 
-        TestHelper::createNewView($postOne);
-        TestHelper::createNewView($postOne);
-        TestHelper::createNewView($postOne);
+        TestHelper::createView($postOne);
+        TestHelper::createView($postOne);
+        TestHelper::createView($postOne);
 
-        TestHelper::createNewView($postTwo);
+        TestHelper::createView($postTwo);
 
-        TestHelper::createNewView($postThree);
-        TestHelper::createNewView($postThree);
+        TestHelper::createView($postThree);
+        TestHelper::createView($postThree);
 
         $this->assertEquals(collect([1, 3, 2]), Post::orderByViews()->pluck('id'));
     }
@@ -65,14 +65,14 @@ class ViewableTest extends TestCase
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
 
-        TestHelper::createNewView($postOne, ['visitor' => 'visitor_one']);
-        TestHelper::createNewView($postOne, ['visitor' => 'visitor_two']);
-        TestHelper::createNewView($postOne, ['visitor' => 'visitor_three']);
+        TestHelper::createView($postOne, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postOne, ['visitor' => 'visitor_two']);
+        TestHelper::createView($postOne, ['visitor' => 'visitor_three']);
 
-        TestHelper::createNewView($postTwo, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postTwo, ['visitor' => 'visitor_one']);
 
-        TestHelper::createNewView($postThree, ['visitor' => 'visitor_one']);
-        TestHelper::createNewView($postThree, ['visitor' => 'visitor_two']);
+        TestHelper::createView($postThree, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postThree, ['visitor' => 'visitor_two']);
 
         $this->assertEquals(collect([1, 3, 2]), Post::orderByUniqueViews()->pluck('id'));
     }
@@ -84,14 +84,14 @@ class ViewableTest extends TestCase
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
 
-        TestHelper::createNewView($postOne);
-        TestHelper::createNewView($postOne);
-        TestHelper::createNewView($postOne);
+        TestHelper::createView($postOne);
+        TestHelper::createView($postOne);
+        TestHelper::createView($postOne);
 
-        TestHelper::createNewView($postTwo);
+        TestHelper::createView($postTwo);
 
-        TestHelper::createNewView($postThree);
-        TestHelper::createNewView($postThree);
+        TestHelper::createView($postThree);
+        TestHelper::createView($postThree);
 
         $this->assertEquals(collect([2, 3, 1]), Post::orderByViews('asc')->pluck('id'));
     }
@@ -103,14 +103,14 @@ class ViewableTest extends TestCase
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
 
-        TestHelper::createNewView($postOne, ['visitor' => 'visitor_one']);
-        TestHelper::createNewView($postOne, ['visitor' => 'visitor_two']);
-        TestHelper::createNewView($postOne, ['visitor' => 'visitor_three']);
+        TestHelper::createView($postOne, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postOne, ['visitor' => 'visitor_two']);
+        TestHelper::createView($postOne, ['visitor' => 'visitor_three']);
 
-        TestHelper::createNewView($postTwo, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postTwo, ['visitor' => 'visitor_one']);
 
-        TestHelper::createNewView($postThree, ['visitor' => 'visitor_one']);
-        TestHelper::createNewView($postThree, ['visitor' => 'visitor_two']);
+        TestHelper::createView($postThree, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postThree, ['visitor' => 'visitor_two']);
 
         $this->assertEquals(collect([2, 3, 1]), Post::orderByUniqueViews('asc')->pluck('id'));
     }
@@ -124,17 +124,17 @@ class ViewableTest extends TestCase
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
 
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
 
-        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
+        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()]);
+        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
 
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()]);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
 
         $this->assertEquals(collect([1, 3, 2]), Post::orderByViews('desc', Period::pastDays(10))->pluck('id'));
     }
@@ -148,18 +148,18 @@ class ViewableTest extends TestCase
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
 
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now(), 'visitor' => 'visitor_one']);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(2), 'visitor' => 'visitor_one']);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(8), 'visitor' => 'visitor_two']);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(13), 'visitor' => 'visitor_three']);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now(), 'visitor' => 'visitor_one']);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(2), 'visitor' => 'visitor_one']);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(8), 'visitor' => 'visitor_two']);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(13), 'visitor' => 'visitor_three']);
 
-        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now(), 'visitor' => 'visitor_one']);
-        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()->subDays(5), 'visitor' => 'visitor_two']);
-        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()->subDays(13), 'visitor' => 'visitor_two']);
+        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now(), 'visitor' => 'visitor_one']);
+        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()->subDays(5), 'visitor' => 'visitor_two']);
+        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()->subDays(13), 'visitor' => 'visitor_two']);
 
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now(), 'visitor' => 'visitor_one']);
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(14), 'visitor' => 'visitor_one']);
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(18), 'visitor' => 'visitor_one']);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now(), 'visitor' => 'visitor_one']);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(14), 'visitor' => 'visitor_one']);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(18), 'visitor' => 'visitor_one']);
 
         $this->assertEquals(collect([3, 2, 1]), Post::orderByUniqueViews('asc', Period::pastDays(10))->pluck('id'));
     }
@@ -173,17 +173,17 @@ class ViewableTest extends TestCase
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
 
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
 
-        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
+        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()]);
+        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
 
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()]);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
 
         $this->assertEquals(collect([1, 3, 2]), Post::orderByViews('desc', Period::pastDays(10))->pluck('id'));
     }
@@ -197,17 +197,17 @@ class ViewableTest extends TestCase
         $postTwo = factory(Post::class)->create();
         $postThree = factory(Post::class)->create();
 
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
-        TestHelper::createNewView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(2)]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(8)]);
+        TestHelper::createView($postOne, ['viewed_at' => Carbon::now()->subDays(13)]);
 
-        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
+        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()]);
+        TestHelper::createView($postTwo, ['viewed_at' => Carbon::now()->subDays(13)]);
 
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()]);
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
-        TestHelper::createNewView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()]);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(8)]);
+        TestHelper::createView($postThree, ['viewed_at' => Carbon::now()->subDays(13)]);
 
         $this->assertEquals(collect([2, 3, 1]), Post::orderByViews('asc', Period::pastDays(10))->pluck('id'));
     }

--- a/tests/Unit/ViewsTest.php
+++ b/tests/Unit/ViewsTest.php
@@ -137,9 +137,9 @@ class ViewsTest extends TestCase
     /** @test */
     public function it_can_count_the_unique_views()
     {
-        TestHelper::createNewView($this->post, ['visitor' => 'visitor_one']);
-        TestHelper::createNewView($this->post, ['visitor' => 'visitor_one']);
-        TestHelper::createNewView($this->post, ['visitor' => 'visitor_two']);
+        TestHelper::createView($this->post, ['visitor' => 'visitor_one']);
+        TestHelper::createView($this->post, ['visitor' => 'visitor_one']);
+        TestHelper::createView($this->post, ['visitor' => 'visitor_two']);
 
         $this->assertEquals(2, views($this->post)->unique()->count());
     }
@@ -149,12 +149,12 @@ class ViewsTest extends TestCase
     {
         Carbon::setTestNow(Carbon::now());
 
-        TestHelper::createNewView($this->post, ['viewed_at' => Carbon::parse('2018-01-10')]);
-        TestHelper::createNewView($this->post, ['viewed_at' => Carbon::parse('2018-01-15')]);
-        TestHelper::createNewView($this->post, ['viewed_at' => Carbon::parse('2018-02-10')]);
-        TestHelper::createNewView($this->post, ['viewed_at' => Carbon::parse('2018-02-15')]);
-        TestHelper::createNewView($this->post, ['viewed_at' => Carbon::parse('2018-03-10')]);
-        TestHelper::createNewView($this->post, ['viewed_at' => Carbon::parse('2018-03-15')]);
+        TestHelper::createView($this->post, ['viewed_at' => Carbon::parse('2018-01-10')]);
+        TestHelper::createView($this->post, ['viewed_at' => Carbon::parse('2018-01-15')]);
+        TestHelper::createView($this->post, ['viewed_at' => Carbon::parse('2018-02-10')]);
+        TestHelper::createView($this->post, ['viewed_at' => Carbon::parse('2018-02-15')]);
+        TestHelper::createView($this->post, ['viewed_at' => Carbon::parse('2018-03-10')]);
+        TestHelper::createView($this->post, ['viewed_at' => Carbon::parse('2018-03-15')]);
 
         $this->assertEquals(6, views($this->post)->period(Period::since(Carbon::parse('2018-01-10')))->count());
         $this->assertEquals(4, views($this->post)->period(Period::upto(Carbon::parse('2018-02-15')))->count());
@@ -175,9 +175,9 @@ class ViewsTest extends TestCase
     /** @test */
     public function it_can_destroy_the_views()
     {
-        TestHelper::createNewView($this->post);
-        TestHelper::createNewView($this->post);
-        TestHelper::createNewView($this->post);
+        TestHelper::createView($this->post);
+        TestHelper::createView($this->post);
+        TestHelper::createView($this->post);
 
         views($this->post)->destroy();
 
@@ -191,11 +191,11 @@ class ViewsTest extends TestCase
         $postTwo = factory(Post::class)->create();
         $apartment = factory(Apartment::class)->create();
 
-        TestHelper::createNewView($postOne);
-        TestHelper::createNewView($postTwo);
-        TestHelper::createNewView($postTwo);
-        TestHelper::createNewView($apartment);
-        TestHelper::createNewView($apartment);
+        TestHelper::createView($postOne);
+        TestHelper::createView($postTwo);
+        TestHelper::createView($postTwo);
+        TestHelper::createView($apartment);
+        TestHelper::createView($apartment);
 
         $this->assertEquals(3, app(Views::class)->countByType(Post::class));
         $this->assertEquals(3, app(Views::class)->countByType($postOne));
@@ -208,11 +208,11 @@ class ViewsTest extends TestCase
         $postTwo = factory(Post::class)->create();
         $apartment = factory(Apartment::class)->create();
 
-        TestHelper::createNewView($postOne, ['visitor' => 'visitor_one']);
-        TestHelper::createNewView($postTwo, ['visitor' => 'visitor_two']);
-        TestHelper::createNewView($postTwo, ['visitor' => 'visitor_one']);
-        TestHelper::createNewView($apartment, ['visitor' => 'visitor_three']);
-        TestHelper::createNewView($apartment, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postOne, ['visitor' => 'visitor_one']);
+        TestHelper::createView($postTwo, ['visitor' => 'visitor_two']);
+        TestHelper::createView($postTwo, ['visitor' => 'visitor_one']);
+        TestHelper::createView($apartment, ['visitor' => 'visitor_three']);
+        TestHelper::createView($apartment, ['visitor' => 'visitor_one']);
 
         $this->assertEquals(2, app(Views::class)->unique()->countByType(Post::class));
         $this->assertEquals(2, app(Views::class)->unique()->countByType($postOne));


### PR DESCRIPTION
This draft is aimed to fix the orderBy query scopes in the `Viewable` trait. 

Fixes #144 

### To do

- [ ] Isolate problem with better tests