### PR TITLE
remove getTable typehint

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -40,7 +40,7 @@ class View extends Model implements ViewContract
      *
      * @return string
      */
-    public function getTable(): string
+    public function getTable()
     {
         return config('eloquent-viewable.models.view.table_name', parent::getTable());
     }


### PR DESCRIPTION
remove getTable typehint so we can override it in the child class with different return type also getTable function in parent model class doesn't have typehint 