### PR TITLE
Allow viewable type as argument in global views() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,12 +316,10 @@ Post::orderByUniqueViews('desc', Period::pastDays(3))->get(); // ascending
 
 ### Get views count of viewable type
 
-If you want to know how many views a specific viewable type has, you can reuse the same `count` method, but need to pass an empty instance of the viewable type to the `views()` helper.
-
-<!-- // Under the hood the package will get the fully qualified class name by calling the `getMorphClass` method on the model and . -->
+If you want to know how many views a specific viewable type has, you need to pass an empty Eloquent model to the `views()` helper like so:
 
 ```php
-views()->count(new Post());
+views(new Post())->count();
 ```
 
 You can also pass a fully qualified class name. The package will then resolve an instance from the application container.

--- a/README.md
+++ b/README.md
@@ -316,17 +316,19 @@ Post::orderByUniqueViews('desc', Period::pastDays(3))->get(); // ascending
 
 ### Get views count of viewable type
 
-If you want to know how many views a specific viewable type has, you can use the `getViewsCountByType` method on the `Views` class.
+If you want to know how many views a specific viewable type has, you can reuse the same `count` method, but need to pass an empty instance of the viewable type to the `views()` helper.
+
+<!-- // Under the hood the package will get the fully qualified class name by calling the `getMorphClass` method on the model and . -->
 
 ```php
-views()->countByType(Post::class);
-views()->countByType('App\Post');
+views()->count(new Post());
 ```
 
-You can also pass an instance of an Eloquent model. It will get the fully qualified class name by calling the `getMorphClass` method on the model.
+You can also pass a fully qualified class name. The package will then resolve an instance from the application container.
 
 ```php
-views()->countByType($post);
+views(Post::class)->count();
+views('App\Post')->count();
 ```
 
 ## Advanced Usage

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -28,24 +28,17 @@ class CacheKey
     /**
      * Create a new cache key instance.
      *
+     * @param  \CyrildeWit\EloquentViewable\Contracts\Viewable|null  $viewable|
      * @return void
      */
-    public function __construct(
-        ViewableContract $viewable = null,
-        string $viewableType = null
-    ) {
+    public function __construct(ViewableContract $viewable = null)
+    {
         $this->viewable = $viewable;
-        $this->viewableType = $viewableType;
     }
 
     public static function fromViewable(ViewableContract $viewable)
     {
         return new static($viewable);
-    }
-
-    public static function fromViewableType(string $viewableType)
-    {
-        return new static(null, $viewableType);
     }
 
     /**
@@ -77,25 +70,11 @@ class CacheKey
 
     protected function getConnectionName(): string
     {
-        // Since don't know anything about the connection of the viewable type origin,
-        // we need to return an empty string to prevent an exception.
-        // TODO: look if an alternative solution could resolve this issue.
-        if ($this->viewable === null && $this->viewableType !== null) {
-            return '';
-        }
-
         return $this->viewable->getConnection()->getName().':';
     }
 
     protected function getDatabaseName(): string
     {
-        // Since don't know anything about the connection of the viewable type origin,
-        // we need to return an empty string to prevent an exception.
-        // TODO: look if an alternative solution could resolve this issue.
-        if ($this->viewable === null && $this->viewableType !== null) {
-            return '';
-        }
-
         return $this->viewable->getConnection()->getDatabaseName().':';
     }
 
@@ -110,35 +89,16 @@ class CacheKey
 
     protected function getTableSlug(): string
     {
-        // Since don't know anything about the connection of the viewable type origin,
-        // we need to return an empty string to prevent an exception.
-        // TODO: look if an alternative solution could resolve this issue.
-        if ($this->viewable === null && $this->viewableType !== null) {
-            return '';
-        }
-
         return app(Str::class)->slug($this->viewable->getTable()).':';
     }
 
     protected function getModelSlug(): string
     {
-        // TODO: look if an alternative solution could improve this ugluy code
-        if ($this->viewable === null && $this->viewableType !== null) {
-            return app(Str::class)->slug($this->viewableType).'.';
-        }
-
         return app(Str::class)->slug($this->viewable->getMorphClass()).'.';
     }
 
     protected function getKeySlug(): string
     {
-        // Since don't know anything about the connection of the viewable type origin,
-        // we need to return an empty string to prevent an exception.
-        // TODO: look if an alternative solution could resolve this issue.
-        if ($this->viewable === null && $this->viewableType !== null) {
-            return '';
-        }
-
         if ($this->viewable->getKey() === null) {
             return '';
         }

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -59,6 +59,7 @@ class CacheKey
         $key = $this->getCachePrefix();
         $key .= $this->getConnectionName();
         $key .= $this->getDatabaseName();
+        $key .= $this->getViewableTypeSlug();
         $key .= $this->getTableSlug();
         $key .= $this->getModelSlug();
         $key .= $this->getKeySlug();
@@ -98,6 +99,15 @@ class CacheKey
         return $this->viewable->getConnection()->getDatabaseName().':';
     }
 
+    protected function getViewableTypeSlug(): string
+    {
+        if ($this->viewable !== null && $this->viewable->getKey() === null) {
+            return 'type.';
+        }
+
+        return '';
+    }
+
     protected function getTableSlug(): string
     {
         // Since don't know anything about the connection of the viewable type origin,
@@ -126,6 +136,10 @@ class CacheKey
         // we need to return an empty string to prevent an exception.
         // TODO: look if an alternative solution could resolve this issue.
         if ($this->viewable === null && $this->viewableType !== null) {
+            return '';
+        }
+
+        if ($this->viewable->getKey() === null) {
             return '';
         }
 

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -28,7 +28,7 @@ class CacheKey
     /**
      * Create a new cache key instance.
      *
-     * @param  \CyrildeWit\EloquentViewable\Contracts\Viewable|null  $viewable|
+     * @param  \CyrildeWit\EloquentViewable\Contracts\Viewable|null  $viewable
      * @return void
      */
     public function __construct(ViewableContract $viewable = null)
@@ -82,7 +82,7 @@ class CacheKey
 
     protected function getViewableTypeSlug(): string
     {
-        if ($this->viewable !== null && $this->viewable->getKey() === null) {
+        if ($this->viewable->getKey() === null) {
             return 'type.';
         }
 

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -46,6 +46,8 @@ class CacheKey
      *
      * @param  \CyrildeWit\EloquentViewable\Support\Period|null  $period
      * @param  bool  $unique
+     * @param  string|null  $collection
+     * @return string
      */
     public function make($period = null, bool $unique = false, string $collection = null)
     {

--- a/src/Views.php
+++ b/src/Views.php
@@ -202,10 +202,7 @@ class Views
         return $viewsCount;
     }
 
-    protected function makeCacheKey($period = null, bool $unique = false, string $collection = null): string
-    {
-        return (CacheKey::fromViewable($this->viewable))->make($period, $unique, $collection);
-    }
+
 
     /**
      * Destroy all views of the viewable model.
@@ -358,6 +355,19 @@ class Views
         }
 
         return true;
+    }
+
+    /**
+     * Make a cache key for the viewable with custom query options.
+     *
+     * @param  \CyrildeWit\EloquentViewable\Support\Period|null  $period
+     * @param  bool  $unique
+     * @param  string|null  $collection
+     * @return string
+     */
+    protected function makeCacheKey($period = null, bool $unique = false, string $collection = null): string
+    {
+        return (CacheKey::fromViewable($this->viewable))->make($period, $unique, $collection);
     }
 
     /**

--- a/src/Views.php
+++ b/src/Views.php
@@ -136,24 +136,16 @@ class Views
     }
 
     /**
-     * Save a new record of the made view.
+     * Set the viewable model.
      *
-     * @return bool
+     * @param  \CyrildeWit\EloquentViewable\Contracts\Viewable|null
+     * @return $this
      */
-    public function record(): bool
+    public function forViewable(ViewableContract $viewable = null): self
     {
-        if ($this->shouldRecord()) {
-            $view = app(ViewContract::class);
-            $view->viewable_id = $this->viewable->getKey();
-            $view->viewable_type = $this->viewable->getMorphClass();
-            $view->visitor = $this->resolveVisitorId();
-            $view->collection = $this->collection;
-            $view->viewed_at = Carbon::now();
+        $this->viewable = $viewable;
 
-            return $view->save();
-        }
-
-        return false;
+        return $this;
     }
 
     /**
@@ -196,6 +188,27 @@ class Views
     }
 
     /**
+     * Save a new record of the made view.
+     *
+     * @return bool
+     */
+    public function record(): bool
+    {
+        if ($this->shouldRecord()) {
+            $view = app(ViewContract::class);
+            $view->viewable_id = $this->viewable->getKey();
+            $view->viewable_type = $this->viewable->getMorphClass();
+            $view->visitor = $this->resolveVisitorId();
+            $view->collection = $this->collection;
+            $view->viewed_at = Carbon::now();
+
+            return $view->save();
+        }
+
+        return false;
+    }
+
+    /**
      * Destroy all views of the viewable model.
      *
      * @return void
@@ -203,19 +216,6 @@ class Views
     public function destroy()
     {
         $this->viewable->views()->delete();
-    }
-
-    /**
-     * Set the viewable model.
-     *
-     * @param  \CyrildeWit\EloquentViewable\Contracts\Viewable|null
-     * @return $this
-     */
-    public function forViewable(ViewableContract $viewable = null): self
-    {
-        $this->viewable = $viewable;
-
-        return $this;
     }
 
     /**

--- a/src/Views.php
+++ b/src/Views.php
@@ -163,14 +163,7 @@ class Views
      */
     public function count(): int
     {
-        // If null, we take for granted that we need to count the type
-        if ($this->viewable->getKey() === null) {
-            $viewableType = $this->viewable->getMorphClass();
-
-            $query = app(ViewContract::class)->where('viewable_type', $viewableType);
-        } else {
-            $query = $this->viewable->views();
-        }
+        $query = $this->resolveVewableQuery();
 
         $cacheKey = $this->makeCacheKey($this->period, $this->unique, $this->collection);
 
@@ -201,8 +194,6 @@ class Views
 
         return $viewsCount;
     }
-
-
 
     /**
      * Destroy all views of the viewable model.
@@ -355,6 +346,23 @@ class Views
         }
 
         return true;
+    }
+
+    /**
+     * Resolve the viewable query builder instance.
+     *
+     * @return
+     */
+    protected function resolveVewableQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        // If null, we take for granted that we need to count the type
+        if ($this->viewable->getKey() === null) {
+            $viewableType = $this->viewable->getMorphClass();
+
+            return app(ViewContract::class)->where('viewable_type', $viewableType);
+        }
+
+        return $this->viewable->views()->getQuery();
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,10 +1,21 @@
 <?php
 
 use CyrildeWit\EloquentViewable\Views;
+use CyrildeWit\EloquentViewable\Contracts\Viewable as ViewableContract;
 
 if (! function_exists('views')) {
     function views($viewable = null)
     {
-        return app(Views::class)->forViewable($viewable);
+        $builder = app(Views::class);
+
+        if (is_string($viewable)) {
+            $model = app($viewable);
+
+            if ($model instanceof ViewableContract) {
+                $viewable = $model;
+            }
+        }
+
+        return $builder->forViewable($viewable);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CyrildeWit\EloquentViewable\Tests;
 
+use Closure;
 use Mockery;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\File;
@@ -114,5 +115,17 @@ abstract class TestCase extends Orchestra
     protected function registerPackageFactories()
     {
         $this->withFactories(realpath(__DIR__.'/database/factories'));
+    }
+
+    /**
+     * Mock an instance of an object in the container.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|null  $mock
+     * @return object
+     */
+    protected function mock($abstract, Closure $mock = null)
+    {
+        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
     }
 }

--- a/tests/Unit/CacheKeyTest.php
+++ b/tests/Unit/CacheKeyTest.php
@@ -145,15 +145,4 @@ class CacheKeyTest extends TestCase
             $secondPostCacheKey->make(null, false, 'some-collection')
         );
     }
-
-    /** @test */
-    public function it_can_make_a_key_from_a_viewable_type()
-    {
-        $cacheKey = new CacheKey(null, Post::class);
-
-        $this->assertEquals(
-            'test-namespace:cyrildewiteloquentviewabletestsstubsmodelspost.|.normal',
-            $cacheKey->make()
-        );
-    }
 }

--- a/tests/Unit/ViewsHelperTest.php
+++ b/tests/Unit/ViewsHelperTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Eloquent Viewable package.
+ *
+ * (c) Cyril de Wit <github@cyrildewit.nl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CyrildeWit\EloquentViewable\Tests\Unit;
+
+use CyrildeWit\EloquentViewable\Views;
+use CyrildeWit\EloquentViewable\Tests\TestCase;
+use CyrildeWit\EloquentViewable\Tests\Stubs\Models\Post;
+
+class ViewsHelperTest extends TestCase
+{
+    /** @test */
+    public function it_accepts_null_as_viewable()
+    {
+        $this->assertInstanceOf(Views::class, views());
+    }
+
+    /** @test */
+    public function it_accepts_a_fully_qualified_class_name_as_viewable()
+    {
+        $this->assertInstanceOf(Views::class, views(Post::class));
+    }
+
+    /** @test */
+    public function it_accepts_an_empty_model_instance_as_viewable()
+    {
+        $this->assertInstanceOf(Views::class, views(new Post()));
+    }
+}

--- a/tests/Unit/ViewsTest.php
+++ b/tests/Unit/ViewsTest.php
@@ -214,8 +214,7 @@ class ViewsTest extends TestCase
         TestHelper::createView($apartment);
         TestHelper::createView($apartment);
 
-        $this->assertEquals(3, app(Views::class)->countByType(Post::class));
-        $this->assertEquals(3, app(Views::class)->countByType($postOne));
+        $this->assertEquals(3, views(new Post())->count());
     }
 
     /** @test */
@@ -231,8 +230,8 @@ class ViewsTest extends TestCase
         TestHelper::createView($apartment, ['visitor' => 'visitor_three']);
         TestHelper::createView($apartment, ['visitor' => 'visitor_one']);
 
-        $this->assertEquals(2, app(Views::class)->unique()->countByType(Post::class));
-        $this->assertEquals(2, app(Views::class)->unique()->countByType($postOne));
+        $this->assertEquals(2, views(Post::class)->unique()->count());
+        $this->assertEquals(2, views(new Post())->unique()->count());
     }
 
     /** @test */
@@ -278,12 +277,12 @@ class ViewsTest extends TestCase
         views($apartment)->record();
         views($apartment)->record();
 
-        $this->assertEquals(3, views()->remember()->countByType(Post::class));
+        $this->assertEquals(3, views(Post::class)->remember()->count());
 
         views($postTwo)->record();
         views($apartment)->record();
 
-        $this->assertEquals(3, views()->remember()->countByType(Post::class));
+        $this->assertEquals(3, views(Post::class)->remember()->count());
     }
 
     /** @test */

--- a/tests/Unit/ViewsTest.php
+++ b/tests/Unit/ViewsTest.php
@@ -44,13 +44,13 @@ class ViewsTest extends TestCase
             return 'someValue';
         });
 
-        $this->assertEquals('someValue', views()->newMethod());
+        $this->assertEquals('someValue', app(Views::class)->newMethod());
     }
 
     /** @test */
     public function it_can_record_a_view()
     {
-        views($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
 
         $this->assertEquals(1, View::count());
     }
@@ -58,9 +58,9 @@ class ViewsTest extends TestCase
     /** @test */
     public function it_can_record_multiple_views()
     {
-        views($this->post)->record();
-        views($this->post)->record();
-        views($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
 
         $this->assertEquals(3, View::count());
     }
@@ -68,11 +68,13 @@ class ViewsTest extends TestCase
     /** @test */
     public function it_does_not_record_views_if_session_delay_is_active()
     {
-        views($this->post)
+        app(Views::class)
+            ->forViewable($this->post)
             ->delayInSession(Carbon::now()->addMinutes(10))
             ->record();
 
-        views($this->post)
+        app(Views::class)
+            ->forViewable($this->post)
             ->delayInSession(Carbon::now()->addMinutes(10))
             ->record();
 
@@ -82,11 +84,13 @@ class ViewsTest extends TestCase
     /** @test */
     public function it_can_record_a_view_with_session_delay_where_delay_is_an_integer()
     {
-        views($this->post)
+        app(Views::class)
+            ->forViewable($this->post)
             ->delayInSession(10)
             ->record();
 
-        views($this->post)
+        app(Views::class)
+            ->forViewable($this->post)
             ->delayInSession(10)
             ->record();
 
@@ -96,11 +100,14 @@ class ViewsTest extends TestCase
     /** @test */
     public function it_can_record_a_view_under_a_collection()
     {
-        views($this->post)
+        app(Views::class)
+            ->forViewable($this->post)
             ->collection('customCollection')
             ->record();
 
-        views($this->post)->record();
+        app(Views::class)
+            ->forViewable($this->post)
+            ->record();
 
         $this->assertEquals(1, View::where('collection', 'customCollection')->count());
     }
@@ -112,11 +119,13 @@ class ViewsTest extends TestCase
             '100.13.20.120',
         ]);
 
-        views($this->post)
+        app(Views::class)
+            ->forViewable($this->post)
             ->useIpAddress('128.42.77.5')
             ->record();
 
-        views($this->post)
+        app(Views::class)
+            ->forViewable($this->post)
             ->useIpAddress('100.13.20.120')
             ->record();
 
@@ -130,11 +139,13 @@ class ViewsTest extends TestCase
             '100.13.20.120',
         ]);
 
-        views($this->post)
+        app(Views::class)
+            ->forViewable($this->post)
             ->useIpAddress('128.42.77.5')
             ->record();
 
-        views($this->post)
+        app(Views::class)
+            ->forViewable($this->post)
             ->useIpAddress('100.13.20.120')
             ->record();
 
@@ -144,11 +155,11 @@ class ViewsTest extends TestCase
     /** @test */
     public function it_can_count_the_views()
     {
-        views($this->post)->record();
-        views($this->post)->record();
-        views($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
 
-        $this->assertEquals(3, views($this->post)->count());
+        $this->assertEquals(3, app(Views::class)->forViewable($this->post)->count());
     }
 
     /** @test */
@@ -158,7 +169,7 @@ class ViewsTest extends TestCase
         TestHelper::createView($this->post, ['visitor' => 'visitor_one']);
         TestHelper::createView($this->post, ['visitor' => 'visitor_two']);
 
-        $this->assertEquals(2, views($this->post)->unique()->count());
+        $this->assertEquals(2, app(Views::class)->forViewable($this->post)->unique()->count());
     }
 
     /** @test */
@@ -173,20 +184,20 @@ class ViewsTest extends TestCase
         TestHelper::createView($this->post, ['viewed_at' => Carbon::parse('2018-03-10')]);
         TestHelper::createView($this->post, ['viewed_at' => Carbon::parse('2018-03-15')]);
 
-        $this->assertEquals(6, views($this->post)->period(Period::since(Carbon::parse('2018-01-10')))->count());
-        $this->assertEquals(4, views($this->post)->period(Period::upto(Carbon::parse('2018-02-15')))->count());
-        $this->assertEquals(4, views($this->post)->period(Period::create(Carbon::parse('2018-01-15'), Carbon::parse('2018-03-10')))->count());
+        $this->assertEquals(6, app(Views::class)->forViewable($this->post)->period(Period::since(Carbon::parse('2018-01-10')))->count());
+        $this->assertEquals(4, app(Views::class)->forViewable($this->post)->period(Period::upto(Carbon::parse('2018-02-15')))->count());
+        $this->assertEquals(4, app(Views::class)->forViewable($this->post)->period(Period::create(Carbon::parse('2018-01-15'), Carbon::parse('2018-03-10')))->count());
     }
 
     /** @test */
     public function it_can_count_the_views_with_a_collection()
     {
-        views($this->post)->collection('custom')->record();
-        views($this->post)->collection('custom')->record();
-        views($this->post)->record();
+        app(Views::class)->forViewable($this->post)->collection('custom')->record();
+        app(Views::class)->forViewable($this->post)->collection('custom')->record();
+        app(Views::class)->forViewable($this->post)->record();
 
-        $this->assertEquals(2, views($this->post)->collection('custom')->count());
-        $this->assertEquals(1, views($this->post)->count());
+        $this->assertEquals(2, app(Views::class)->forViewable($this->post)->collection('custom')->count());
+        $this->assertEquals(1, app(Views::class)->forViewable($this->post)->count());
     }
 
     /** @test */
@@ -196,9 +207,9 @@ class ViewsTest extends TestCase
         TestHelper::createView($this->post);
         TestHelper::createView($this->post);
 
-        views($this->post)->destroy();
+        app(Views::class)->forViewable($this->post)->destroy();
 
-        $this->assertEquals(0, views($this->post)->count());
+        $this->assertEquals(0, app(Views::class)->forViewable($this->post)->count());
     }
 
     /** @test */
@@ -214,7 +225,7 @@ class ViewsTest extends TestCase
         TestHelper::createView($apartment);
         TestHelper::createView($apartment);
 
-        $this->assertEquals(3, views(new Post())->count());
+        $this->assertEquals(3, app(Views::class)->forViewable(new Post())->count());
     }
 
     /** @test */
@@ -230,38 +241,38 @@ class ViewsTest extends TestCase
         TestHelper::createView($apartment, ['visitor' => 'visitor_three']);
         TestHelper::createView($apartment, ['visitor' => 'visitor_one']);
 
-        $this->assertEquals(2, views(Post::class)->unique()->count());
-        $this->assertEquals(2, views(new Post())->unique()->count());
+        $this->assertEquals(2, app(Views::class)->forViewable(new Post())->unique()->count());
+        $this->assertEquals(2, app(Views::class)->forViewable(new Post())->unique()->count());
     }
 
     /** @test */
     public function it_can_remember_the_views_counts()
     {
-        views($this->post)->record();
-        views($this->post)->record();
-        views($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
 
-        $this->assertEquals(3, views($this->post)->remember()->count());
+        $this->assertEquals(3, app(Views::class)->forViewable($this->post)->remember()->count());
 
-        views($this->post)->record();
-        views($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
 
-        $this->assertEquals(3, views($this->post)->remember()->count());
+        $this->assertEquals(3, app(Views::class)->forViewable($this->post)->remember()->count());
     }
 
     /** @test */
     public function it_can_remember_the_views_counts_with_custom_lifetime()
     {
-        views($this->post)->record();
-        views($this->post)->record();
-        views($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
 
-        $this->assertEquals(3, views($this->post)->remember(10)->count());
+        $this->assertEquals(3, app(Views::class)->forViewable($this->post)->remember(10)->count());
 
-        views($this->post)->record();
-        views($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
 
-        $this->assertEquals(3, views($this->post)->remember(10)->count());
+        $this->assertEquals(3, app(Views::class)->forViewable($this->post)->remember(10)->count());
     }
 
     /** @test */
@@ -271,16 +282,16 @@ class ViewsTest extends TestCase
         $postTwo = factory(Post::class)->create();
         $apartment = factory(Apartment::class)->create();
 
-        views($postOne)->record();
-        views($postTwo)->record();
-        views($postTwo)->record();
-        views($apartment)->record();
-        views($apartment)->record();
+        app(Views::class)->forViewable($postOne)->record();
+        app(Views::class)->forViewable($postTwo)->record();
+        app(Views::class)->forViewable($postTwo)->record();
+        app(Views::class)->forViewable($apartment)->record();
+        app(Views::class)->forViewable($apartment)->record();
 
         $this->assertEquals(3, views(Post::class)->remember()->count());
 
-        views($postTwo)->record();
-        views($apartment)->record();
+        app(Views::class)->forViewable($postTwo)->record();
+        app(Views::class)->forViewable($apartment)->record();
 
         $this->assertEquals(3, views(Post::class)->remember()->count());
     }
@@ -298,9 +309,8 @@ class ViewsTest extends TestCase
             };
         });
 
-        views($this->post)->record();
-        views($this->post)->record();
-        views($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
 
         $this->assertEquals(0, View::count());
     }
@@ -315,9 +325,9 @@ class ViewsTest extends TestCase
             $mock->shouldReceive('isCrawler')->andReturn(false);
         });
 
-        views($this->post)->record();
-        views($this->post)->record();
-        views($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
 
         $this->assertEquals(0, View::count());
     }
@@ -335,8 +345,8 @@ class ViewsTest extends TestCase
             $mock->shouldReceive('isCrawler')->andReturn(false);
         });
 
-        views($this->post)->record();
-        views($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
+        app(Views::class)->forViewable($this->post)->record();
 
         $this->assertEquals(0, View::count());
     }


### PR DESCRIPTION
This pull request totally changes the concept of how we query on viewable types. A viewable type is basically the fully qualified class name of a model. Thus if we have a Post model, the viewable type may be for example `App\Post`. This string is also stored in each view record.

In `v4.0.0` you can use the `countByType` method to count the viewable type. This PR changes that by removing this method and bringing the functionality under the `count` method.

