### PR TITLE
[5.x] Better Eloquent Integration

### DIFF
--- a/src/Contracts/View.php
+++ b/src/Contracts/View.php
@@ -25,12 +25,4 @@ interface View
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWithinPeriod(Builder $query, Period $period);
-
-    /**
-     * Scope a query to only include unique views.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder $query
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopeUniqueVisitor(Builder $query);
 }

--- a/src/OrderByViewsScope.php
+++ b/src/OrderByViewsScope.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CyrildeWit\EloquentViewable;
 
-use CyrildeWit\EloquentViewable\Contracts\View as ViewContract;
 use CyrildeWit\EloquentViewable\Enums\SortDirection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;

--- a/src/OrderByViewsScope.php
+++ b/src/OrderByViewsScope.php
@@ -7,6 +7,7 @@ namespace CyrildeWit\EloquentViewable;
 use CyrildeWit\EloquentViewable\Contracts\View as ViewContract;
 use CyrildeWit\EloquentViewable\Enums\SortDirection;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 
 class OrderByViewsScope
 {
@@ -25,41 +26,20 @@ class OrderByViewsScope
         $period = $options['period'] ?? null;
         $collection = $options['collection'] ?? null;
 
-        $viewable = $query->getModel();
-        $viewModel = app(ViewContract::class);
-        $viewableTable = $viewable->getTable();
-        $viewsTable = $viewModel->getTable();
-        $distinctQuery = '';
-
-        $query->leftJoin($viewsTable, function ($join) use ($viewsTable, $viewableTable, $viewable, $collection) {
-            $join->on("{$viewsTable}.viewable_id", '=', "{$viewableTable}.{$viewable->getKeyName()}");
-            $join->where("{$viewsTable}.viewable_type", '=', "{$viewable->getMorphClass()}");
+        $query->withCount(['views as views_count' => function (Builder $query) use ($unique, $direction, $period, $collection) {
+            if ($period) {
+                $query->withinPeriod($period);
+            }
 
             if ($collection) {
-                $join->where("{$viewsTable}.collection", '=', $collection);
+                $query->collection($collection);
             }
-        });
 
-        if ($unique) {
-            $distinctQuery = 'distinct ';
-        }
-
-        $query->selectRaw("{$viewable->getConnection()->getTablePrefix()}{$viewableTable}.*, count({$distinctQuery}visitor) as views_count");
-
-        if ($period) {
-            $startDateTime = $period->getStartDateTime();
-            $endDateTime = $period->getEndDateTime();
-
-            if ($startDateTime && ! $endDateTime) {
-                $query->where("{$viewsTable}.viewed_at", '>=', $startDateTime);
-            } elseif (! $startDateTime && $endDateTime) {
-                $query->where("{$viewsTable}.viewed_at", '<=', $endDateTime);
-            } elseif ($startDateTime && $endDateTime) {
-                $query->whereBetween("{$viewsTable}.viewed_at", [$startDateTime, $endDateTime]);
+            if ($unique) {
+                $query->select(DB::raw('count(DISTINCT visitor)'));
             }
-        }
+        }]);
 
-        return $query->groupBy("{$viewable->getTable()}.{$viewable->getKeyName()}")
-            ->orderBy('views_count', $direction);
+        return $query->orderBy('views_count', $direction);
     }
 }

--- a/src/View.php
+++ b/src/View.php
@@ -90,15 +90,4 @@ class View extends Model implements ViewContract
     {
         return $query->where('collection', $collection);
     }
-
-    /**
-     * Scope a query to only include unique views.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder $query
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopeUniqueVisitor(Builder $query)
-    {
-        return $query->distinct('visitor');
-    }
 }

--- a/src/Viewable.php
+++ b/src/Viewable.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CyrildeWit\EloquentViewable;
 
 use CyrildeWit\EloquentViewable\Contracts\View as ViewContract;
+use CyrildeWit\EloquentViewable\Enums\SortDirection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
@@ -62,7 +63,7 @@ trait Viewable
     public function scopeOrderByUniqueViews(Builder $query, string $direction = 'desc', $period = null, string $collection = null): Builder
     {
         return (new OrderByViewsScope())->apply($query, [
-            'descending' => $direction === 'desc',
+            'descending' => $direction === SortDirection::DESCENDING,
             'period' => $period,
             'unique' => true,
             'collection' => $collection,

--- a/src/Viewable.php
+++ b/src/Viewable.php
@@ -15,7 +15,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 trait Viewable
 {
     /**
-     * HasViews boot logic.
+     * Viewable boot logic.
      *
      * @return void
      */

--- a/src/Views.php
+++ b/src/Views.php
@@ -17,6 +17,7 @@ use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
+use Illuminate\Support\Facades\DB;
 
 class Views implements ViewsContract
 {

--- a/src/Views.php
+++ b/src/Views.php
@@ -15,9 +15,9 @@ use DateTime;
 use DateTimeInterface;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
-use Illuminate\Support\Facades\DB;
 
 class Views implements ViewsContract
 {

--- a/src/Views.php
+++ b/src/Views.php
@@ -164,8 +164,8 @@ class Views implements ViewsContract
             }
         }
 
-        if ($period = $this->period) {
-            $query->withinPeriod($period);
+        if ($this->period) {
+            $query->withinPeriod($this->period);
         }
 
         $query->collection($this->collection);

--- a/src/Views.php
+++ b/src/Views.php
@@ -170,11 +170,7 @@ class Views implements ViewsContract
 
         $query->collection($this->collection);
 
-        if ($this->unique) {
-            $viewsCount = $query->uniqueVisitor()->count('visitor');
-        } else {
-            $viewsCount = $query->count();
-        }
+        $viewsCount = $this->unique ? $query->count(DB::raw('DISTINCT visitor')) : $query->count();
 
         if ($this->shouldCache()) {
             $this->cache->put($cacheKey, $viewsCount, $this->cacheLifetime);

--- a/src/Views.php
+++ b/src/Views.php
@@ -146,7 +146,7 @@ class Views implements ViewsContract
     }
 
     /**
-     * Count the views.
+     * Get the views count.
      *
      * @return int
      */

--- a/tests/OrderByViewsScopeTest.php
+++ b/tests/OrderByViewsScopeTest.php
@@ -16,7 +16,7 @@ class OrderByViewsScopeTest extends TestCase
         $query = (new OrderByViewsScope())->apply(Post::query());
 
         $this->assertEquals(
-            'select posts.*, count(visitor) as views_count from "posts" left join "views" on "views"."viewable_id" = "posts"."id" and "views"."viewable_type" = ? group by "posts"."id" order by "views_count" asc',
+            'select "posts".*, (select count(*) from "views" where "posts"."id" = "views"."viewable_id" and "views"."viewable_type" = ?) as "views_count" from "posts" order by "views_count" asc',
             $query->toSql()
         );
     }
@@ -29,20 +29,20 @@ class OrderByViewsScopeTest extends TestCase
         ]);
 
         $this->assertEquals(
-            'select posts.*, count(distinct visitor) as views_count from "posts" left join "views" on "views"."viewable_id" = "posts"."id" and "views"."viewable_type" = ? group by "posts"."id" order by "views_count" asc',
+            'select "posts".*, (select count(DISTINCT visitor) from "views" where "posts"."id" = "views"."viewable_id" and "views"."viewable_type" = ?) as "views_count" from "posts" order by "views_count" asc',
             $query->toSql()
         );
     }
 
     /** @test */
-    public function it_builds_a_query_with_option_direction()
+    public function it_builds_a_query_with_option_descending()
     {
         $query = (new OrderByViewsScope())->apply(Post::query(), [
             'descending' => true,
         ]);
 
         $this->assertEquals(
-            'select posts.*, count(visitor) as views_count from "posts" left join "views" on "views"."viewable_id" = "posts"."id" and "views"."viewable_type" = ? group by "posts"."id" order by "views_count" desc',
+            'select "posts".*, (select count(*) from "views" where "posts"."id" = "views"."viewable_id" and "views"."viewable_type" = ?) as "views_count" from "posts" order by "views_count" desc',
             $query->toSql()
         );
     }
@@ -55,7 +55,7 @@ class OrderByViewsScopeTest extends TestCase
         ]);
 
         $this->assertEquals(
-            'select posts.*, count(visitor) as views_count from "posts" left join "views" on "views"."viewable_id" = "posts"."id" and "views"."viewable_type" = ? where "views"."viewed_at" >= ? group by "posts"."id" order by "views_count" asc',
+            'select "posts".*, (select count(*) from "views" where "posts"."id" = "views"."viewable_id" and "views"."viewable_type" = ? and "viewed_at" >= ?) as "views_count" from "posts" order by "views_count" asc',
             $query->toSql()
         );
     }
@@ -68,7 +68,7 @@ class OrderByViewsScopeTest extends TestCase
         ]);
 
         $this->assertEquals(
-            'select posts.*, count(visitor) as views_count from "posts" left join "views" on "views"."viewable_id" = "posts"."id" and "views"."viewable_type" = ? where "views"."viewed_at" <= ? group by "posts"."id" order by "views_count" asc',
+            'select "posts".*, (select count(*) from "views" where "posts"."id" = "views"."viewable_id" and "views"."viewable_type" = ? and "viewed_at" <= ?) as "views_count" from "posts" order by "views_count" asc',
             $query->toSql()
         );
     }
@@ -81,7 +81,7 @@ class OrderByViewsScopeTest extends TestCase
         ]);
 
         $this->assertEquals(
-            'select posts.*, count(visitor) as views_count from "posts" left join "views" on "views"."viewable_id" = "posts"."id" and "views"."viewable_type" = ? where "views"."viewed_at" between ? and ? group by "posts"."id" order by "views_count" asc',
+            'select "posts".*, (select count(*) from "views" where "posts"."id" = "views"."viewable_id" and "views"."viewable_type" = ? and "viewed_at" between ? and ?) as "views_count" from "posts" order by "views_count" asc',
             $query->toSql()
         );
     }
@@ -94,7 +94,7 @@ class OrderByViewsScopeTest extends TestCase
         ]);
 
         $this->assertEquals(
-            'select posts.*, count(visitor) as views_count from "posts" left join "views" on "views"."viewable_id" = "posts"."id" and "views"."viewable_type" = ? and "views"."collection" = ? group by "posts"."id" order by "views_count" asc',
+            'select "posts".*, (select count(*) from "views" where "posts"."id" = "views"."viewable_id" and "views"."viewable_type" = ? and "collection" = ?) as "views_count" from "posts" order by "views_count" asc',
             $query->toSql()
         );
     }

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CyrildeWit\EloquentViewable\Tests;
 
 use Carbon\Carbon;
+use CyrildeWit\EloquentViewable\Support\Period;
 use CyrildeWit\EloquentViewable\Tests\TestClasses\Models\Post;
 use CyrildeWit\EloquentViewable\View;
 
@@ -75,5 +76,60 @@ class ViewTest extends TestCase
         ]);
 
         $this->assertInstanceOf(Post::class, View::first()->viewable);
+    }
+
+    /** @test */
+    public function it_can_scope_to_within_period_with_only_start_date_time()
+    {
+        $post = factory(Post::class)->create();
+
+        $this->assertEquals(
+            'select * from "views" where "viewed_at" >= ?',
+            View::withinPeriod(Period::since('2019-06-12'))->toSql()
+        );
+    }
+
+    /** @test */
+    public function it_can_scope_to_within_period_with_only_end_date_time()
+    {
+        $post = factory(Post::class)->create();
+
+        $this->assertEquals(
+            'select * from "views" where "viewed_at" <= ?',
+            View::withinPeriod(Period::upto('2019-03-23'))->toSql()
+        );
+    }
+
+    /** @test */
+    public function it_can_scope_to_within_period_with_both_start_and_end_date_time()
+    {
+        $post = factory(Post::class)->create();
+
+        $this->assertEquals(
+            'select * from "views" where "viewed_at" between ? and ?',
+            View::withinPeriod(Period::create('2019-02-15', '2019-06-12'))->toSql()
+        );
+    }
+
+    /** @test */
+    public function it_can_scope_to_collection_null()
+    {
+        $post = factory(Post::class)->create();
+
+        $this->assertEquals(
+            'select * from "views" where "collection" is null',
+            View::collection(null)->toSql()
+        );
+    }
+
+    /** @test */
+    public function it_can_scope_to_collection_custom()
+    {
+        $post = factory(Post::class)->create();
+
+        $this->assertEquals(
+            'select * from "views" where "collection" = ?',
+            View::collection('custom')->toSql()
+        );
     }
 }


### PR DESCRIPTION
This pull request will refactor the current database/eloquent implementation to take more advantage of Eloquent's features. The biggest refactor was made in the `OrderByViewsScope` class. It now uses the `withCount()` method.

I've removed the `uniqueVisitor` scope from the `View` model. It doesn't always do what it's supposed to do, so I've decided to remove it from the core.

Refactored the `Viewable` trait a little bit and added a few tests for the `View` model.

There is no performance gained with these changes (maybe a few microseconds).