### PR TITLE
Update run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,12 +51,6 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-      - name: Install minimum required Mockery version on PHP 8 with prefer lowest stability
-        if: ${{ matrix.php == '8.0' && matrix.stability == 'prefer-lowest' && (matrix.laravel == '^6.0' || matrix.laravel == '^7.0') }}
-        run: |
-          composer require "mockery/mockery:^1.4.2" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,6 +46,17 @@ jobs:
       - name: Setup Memcached
         uses: niden/actions-memcached@v7
 
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,6 +23,13 @@ jobs:
         exclude:
           - php: 7.4
             laravel: ^9.0
+          - php: 8.1
+            laravel: ^6.0
+          - php: 8.1
+            laravel: ^7.0
+          - php: 8.1
+            laravel: ^8.0
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0]
+        php: [7.4, 8.0, 8.1]
         laravel: [^6.0, ^7.0, ^8.0, ^9.0]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -62,6 +62,12 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
+      - name: Install minimum required Mockery version on PHP 8 with prefer lowest stability
+        if: ${{ matrix.php == '8.0' && matrix.stability == 'prefer-lowest' && (matrix.laravel == '^6.0' || matrix.laravel == '^7.0') }}
+        run: |
+          composer require "mockery/mockery:^1.4.2" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -57,18 +57,6 @@ jobs:
           composer require "mockery/mockery:^1.4.2" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-      - name: Install laravel/legacy-factories 1.1 for Laravel 8.0
-        if: ${{ matrix.laravel == '^8.0' }}
-        run: |
-          composer require "laravel/legacy-factories:^1.1" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
-      - name: Install laravel/legacy-factories 1.3 for Laravel 9.0
-        if: ${{ matrix.laravel == '^9.0' }}
-        run: |
-          composer require "laravel/legacy-factories:^1.3" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,9 +27,6 @@ jobs:
             laravel: ^6.0
           - php: 8.1
             laravel: ^7.0
-          - php: 8.1
-            laravel: ^8.0
-            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
@@ -73,6 +70,16 @@ jobs:
         if: ${{ matrix.php == '8.0' && matrix.stability == 'prefer-lowest' && (matrix.laravel == '^6.0' || matrix.laravel == '^7.0') }}
         run: |
           composer require "mockery/mockery:^1.4.2" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: Install minimum required packages on PHP 8.1 with prefer lowest stability
+        if: ${{ matrix.php == '8.1' && matrix.stability == 'prefer-lowest' && matrix.laravel == '^8.0' }}
+        run: |
+          composer require "laravel/framework:^8.62.0" --no-interaction --no-update
+          composer require "laravel/legacy-factories:^1.1.1" --no-interaction --no-update
+          composer require "nesbot/carbon:^2.51.0" --no-interaction --no-update
+          composer require "symfony/http-foundation:^5.3.7" --no-interaction --no-update
+          composer require "symfony/console:^5.3.7" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          extensions: mbstring
           coverage: xdebug
 
       - name: Setup Memcached

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -57,12 +57,6 @@ jobs:
           composer require "mockery/mockery:^1.4.2" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-      - name: Install fzaninotto/faker
-        if: ${{ matrix.php == '^7.4' }}
-        run: |
-          composer require "fzaninotto/faker:^1.9.1" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
       - name: Install laravel/legacy-factories 1.1 for Laravel 8.0
         if: ${{ matrix.laravel == '^8.0' }}
         run: |


### PR DESCRIPTION
Hello,

I would like to propose some improvements to the CI/CD workflow. This PR:

- adds support of PHP 8.1 (with all necessary exclusions)
- adds caching of composer dependencies (it is really optional, and if it doesn't seem reasonable I'll remove it)
- removes non-used PHP extensions (it speeds up a little bit)
- removes installation of the specific minimum versions of fzaninotto/faker and laravel/legacy-factories (it seems to work perfectly without the specific versions)
- adds installation of the specific minimum versions required by PHP 8.1 and Laravel 8.0 with `prefer-lowest` (I did it just in case. An explanation is below)

**PS** I'd prefer to totally exclude PHP 8.1 and Laralve 8.0 with `prefer-lowest` from processing (because it requires too many different minimum versions). However, the decision is up to you.