### PR TITLE
Fix deprecation warning.

### DIFF
--- a/src/CooldownManager.php
+++ b/src/CooldownManager.php
@@ -86,7 +86,7 @@ class CooldownManager
      * Returns for example:
      * => `eloquent-viewable.session.key.app-models-post`
      */
-    protected function createNamespaceKey(Viewable $viewable, string $collection = null): string
+    protected function createNamespaceKey(Viewable $viewable, ?string $collection = null): string
     {
         $key = $this->primaryKey;
         $key .= '.'.strtolower(str_replace('\\', '-', $viewable->getMorphClass()));

--- a/src/View.php
+++ b/src/View.php
@@ -91,7 +91,7 @@ class View extends Model implements ViewContract
      * @param  string|null  $collection
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeCollection(Builder $query, string $collection = null)
+    public function scopeCollection(Builder $query, ?string $collection = null)
     {
         return $query->where('collection', $collection);
     }


### PR DESCRIPTION
This PR resolves the following deprecation warnings:

```
[19-Mar-2025 01:49:07 UTC] PHP Deprecated: CyrildeWit\EloquentViewable\View::scopeCollection(): Implicitly marking parameter $collection as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/cyrildewit/eloquent-viewable/src/View.php on line 94
```

```
[19-Mar-2025 01:49:07 UTC] PHP Deprecated: CyrildeWit\EloquentViewable\CooldownManager::createNamespaceKey(): Implicitly marking parameter $collection as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/cyrildewit/eloquent-viewable/src/CooldownManager.php on line 89
```