### PR TITLE
Update InteractsWithViews.php

### DIFF
--- a/src/InteractsWithViews.php
+++ b/src/InteractsWithViews.php
@@ -60,7 +60,7 @@ trait InteractsWithViews
         Builder $query,
         string $direction = 'desc',
         $period = null,
-        string $collection = null,
+        ?string $collection = null,
         string $as = 'unique_views_count'
     ): Builder {
         return $query->orderByViews($direction, $period, $collection, true, $as);


### PR DESCRIPTION
Implicitly marking parameter $collection as nullable is deprecated, the explicit nullable type must be used instead.